### PR TITLE
Add Docker Debugger config to launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,19 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "Docker Debugger",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "localRoot": "${workspaceFolder}",
+      "remoteRoot": "/app",
+      "restart": true,
+      "sourceMaps": true,
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Launch Program",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - '3000:3000'
       - '3001:3001' # for browser-sync hot-reloading
       - '3002:3002' # for browser-sync proxy server
+      - '9229:9229' # for debugging in chrome devtools
     env_file:
       - .env.development
     environment:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "fomantic-install": "cd node_modules/fomantic-ui && npx gulp install",
     "fomantic-build": "cd node_modules/fomantic-ui && npx gulp build",
     "start": "nodemon server.js",
-    "dev": "gulp & nodemon server.js",
+    "dev": "gulp & nodemon --inspect=0.0.0.0:9229 server.js",
     "prepare": "husky install",
     "precommit-pug": "prettier --write '**/*.pug' --plugin='@prettier/plugin-pug'",
     "release": "standard-version"


### PR DESCRIPTION
This pull request adds a new configuration to the launch.json file that enables debugging with Docker. The new configuration is called "Docker Debugger" and allows developers to attach the debugger to a running Docker container. This is useful for debugging Node.js applications running inside a Docker container. The configuration specifies the port to use for debugging (9229), the local and remote root directories, and enables source maps for better debugging experience. Additionally, the "outFiles" property is set to include all JavaScript files in the "dist" directory. This PR also includes other minor changes related to debugging, such as adding a debugging port for Chrome DevTools and updating the dev script to enable remote debugging.

Fixes #1234